### PR TITLE
build: Change typer dependency to 'standard' variant

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
-dependencies = ["typer[all]>=0.9.0"]
+dependencies = ["typer[standard]>=0.9.0"]
 
 [project.urls]
 Homepage = "https://github.com/yourusername/ssec-cli"


### PR DESCRIPTION
This pull request updates the dependency specification for the `typer` package in `pyproject.toml` to use the `standard` extra instead of `all`. This change may reduce unnecessary dependencies and streamline the installation process.

- Dependency update:
  * Changed the `typer` dependency from `typer[all]>=0.9.0` to `typer[standard]>=0.9.0` in `pyproject.toml`.