### PR TITLE
Update dependencies format in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
-dependencies = ["typer[standard]>=0.9.0"]
+dependencies = ["typer>=0.9.0"]
 
 [project.urls]
 Homepage = "https://github.com/yourusername/ssec-cli"


### PR DESCRIPTION
Actually typer is equivalent to `typer-slim[standard]` see https://typer.tiangolo.com/tutorial/install/

